### PR TITLE
Add update for bpkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,14 +148,14 @@ Other Alternatives
 
 *Deps* is if the tool supports dependencies. **Locations** is where libraries can be installed (globally, in a user's home folder, or in a specific repository).
 
-    | Software  | Deps | Versions | Locations          |
-    |-----------|------|----------|--------------------|
-    | basher    | Yes  | No       | Global, User       |
-    | [bpkg]    | Yes  | Yes      | Global, Repo       |
-    | `bpm`     | Yes  | No       | Global, User, Repo |
-    | [Jean]    | No   | No       | Global             |
-    | [pkgtool] | Yes  | Yes      | Global             |
-    | [Tarp]    | Yes  | No       | Global             |
+| Software  | Deps | Versions | Locations          |
+|-----------|------|----------|--------------------|
+| basher    | Yes  | No       | Global, User       |
+| [bpkg]    | Yes  | Yes      | Global, User, Repo |
+| `bpm`     | Yes  | No       | Global, User, Repo |
+| [Jean]    | No   | No       | Global             |
+| [pkgtool] | Yes  | Yes      | Global             |
+| [Tarp]    | Yes  | No       | Global             |
 
 * [basher] - No central repository required; uses GitHub repositories. Thoroughly tested code. Includes completions. Geared much more for binary programs instead of Bash libraries. Keeps the package repositories.
 * [bpkg] - Lightweight Bash package manager. Centralized repository for searching and installs inside of a project's "deps" folder. Confusingly, it uses `package.json` like Node.js projects. Meant more for executables.


### PR DESCRIPTION
Since release v0.3.2 `bpkg` now also allows user-level installs.